### PR TITLE
Fix PhpStan seeing things that don't exist.

### DIFF
--- a/src/ORM/Association/Loader/PartitionableSelectWithPivotLoader.php
+++ b/src/ORM/Association/Loader/PartitionableSelectWithPivotLoader.php
@@ -341,6 +341,7 @@ class PartitionableSelectWithPivotLoader extends SelectWithPivotLoader
                 array_keys($resultMap),
                 array_column($resultMap, 0)
             );
+            /** @var array<string, mixed> $resultMap */
             $resultMap = array_filter((array)$resultMap);
         }
 


### PR DESCRIPTION
The initial result map is already using string keys only.